### PR TITLE
Enable lexical binding and autoload cookies

### DIFF
--- a/eshell-up.el
+++ b/eshell-up.el
@@ -1,4 +1,4 @@
-;;; eshell-up.el --- Quickly go to a specific parent directory in eshell
+;;; eshell-up.el --- Quickly go to a specific parent directory in eshell -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2016 Peter W. V. Tran-Jørgensen
 

--- a/eshell-up.el
+++ b/eshell-up.el
@@ -91,6 +91,7 @@ Argument MATCH a string that identifies the parent directory to search for."
                                         nil)))))
       closest-parent)))
 
+;;;###autoload
 (defun eshell-up (&optional match)
   "Go to a specific parent directory in eshell.
 Argument MATCH a string that identifies the parent directory to go
@@ -106,6 +107,7 @@ to."
             (eshell/echo parent-dir)
           (eshell/echo path))))))
 
+;;;###autoload
 (defun eshell-up-peek (&optional match)
   "Find a specific parent directory in eshell.
 Argument MATCH a string that identifies the parent directory to find"


### PR DESCRIPTION
Hi. In Emacs30, not having lexical binding is now a byte compiler warning. I have been using this package for some time with lexical binding enabled and have not encountered any issues nor do I see anything in the code that could cause problems with that.

Also, I have added autoload cookies for the interactive functions so that users do not have to explicitly autoload them.

If any problems do arise, feel free to ping me and I will follow up this PR.
